### PR TITLE
None encoding bugfix

### DIFF
--- a/simple_bson/encoder.py
+++ b/simple_bson/encoder.py
@@ -53,7 +53,7 @@ def encode_bool(name: str, value: bool) -> bytes:
     return TypeSignature.bool + encode_element_name(name) + struct.pack("<b", value)
 
 
-@register((None,))
+@register((type(None),))
 def encode_null(name: str, value: None) -> bytes:
     return TypeSignature.null + encode_element_name(name)
 


### PR DESCRIPTION
Hi there, this fixes the following:

```
>>> import simple_bson
>>> simple_bson.dumps({'x':None})
Traceback (most recent call last):
...
simple_bson.etc.EncodeError: No encoder for : <class 'NoneType'>
```
